### PR TITLE
feat: Add automatic version tag to index page

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,13 +47,25 @@
             font-size: 1em;
             font-weight: bold;
         }
+        #version-info {
+            position: fixed;
+            top: 10px;
+            right: 10px;
+            background-color: rgba(255, 255, 255, 0.8);
+            padding: 5px 10px;
+            border-radius: 5px;
+            font-size: 0.8em;
+            color: #555;
+        }
     </style>
 </head>
 <body>
+    <div id="version-info"></div>
     <h1>p5.js Sketches</h1>
     <div id="sketch-grid">
         <!-- Sketch cards will be inserted here by JavaScript -->
     </div>
     <script src="js/main.js"></script>
+    <script src="js/version.js"></script>
 </body>
 </html>

--- a/js/version.js
+++ b/js/version.js
@@ -1,0 +1,15 @@
+document.addEventListener('DOMContentLoaded', function() {
+    const versionInfo = document.getElementById('version-info');
+
+    fetch('version.json')
+        .then(response => response.json())
+        .then(data => {
+            const version = data.version;
+            const timestamp = data.timestamp;
+            versionInfo.innerHTML = `Version: ${version}<br>Updated: ${timestamp}`;
+        })
+        .catch(error => {
+            console.error('Error loading version information:', error);
+            versionInfo.textContent = 'Could not load version info.';
+        });
+});

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "A collection of p5.js sketches",
   "main": "js/main.js",
   "scripts": {
-    "start": "node server.js"
+    "start": "node server.js",
+    "update-version": "node update-version.js"
   },
   "dependencies": {
     "express": "^4.17.1",

--- a/update-version.js
+++ b/update-version.js
@@ -1,0 +1,17 @@
+const fs = require('fs');
+const { execSync } = require('child_process');
+
+try {
+    const version = execSync('git rev-parse --short HEAD').toString().trim();
+    const timestamp = execSync('git log -1 --format=%cd').toString().trim();
+
+    const versionInfo = {
+        version,
+        timestamp,
+    };
+
+    fs.writeFileSync('version.json', JSON.stringify(versionInfo, null, 2));
+    console.log('Version information updated successfully.');
+} catch (error) {
+    console.error('Error updating version information:', error);
+}

--- a/version.json
+++ b/version.json
@@ -1,0 +1,4 @@
+{
+  "version": "ce178bd",
+  "timestamp": "Thu Sep 25 20:00:57 2025 +0000"
+}


### PR DESCRIPTION
This change introduces an automatic version tag that appears at the top of the index page.

- A `version.json` file is created to store the version (commit hash) and timestamp.
- A Node.js script, `update-version.js`, is added to update `version.json` with the latest git commit information.
- An `npm` script, `update-version`, is added to `package.json` to run the update script.
- The `index.html` page is modified to include a container for the version information and a new JavaScript file, `js/version.js`.
- `js/version.js` fetches the `version.json` file and displays the version and timestamp on the page.

Instructions have been provided to the user on how to set up a `post-commit` Git hook to automate the version update process. This ensures that the version information is always up-to-date with the latest commit.